### PR TITLE
Links in navigation bar require better contrast

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,6 +75,15 @@
   color: rgb(21, 111, 197);
 }
 
+[data-theme=light] .navbar__item:hover {
+  background: #fff;
+  color: #77acd9;
+}
+
+[data-theme=light] .navbar__item.navbar__link--active {
+  box-shadow: inset 0 0 0 1px #fff;
+}
+
 [data-theme="light"]
   .table-of-contents__link.toc-highlight.table-of-contents__link
   > a:hover {
@@ -150,6 +159,15 @@
 [data-theme="dark"]
   .table-of-contents__link.toc-highlight.table-of-contents__link--active {
   color: #77acd9;
+}
+
+[data-theme=dark] .navbar__item:hover {
+  background: #fff;
+  color: #77acd9;
+}
+
+[data-theme=dark] .navbar__item.navbar__link--active {
+  box-shadow: inset 0 0 0 1px #fff;
 }
 
 [data-theme="dark"]


### PR DESCRIPTION
I've done some basic CSS updates to the navigation links to improve the accessibility of the colours used, particularly when the links are being hovered over.

Previously they were white text to blue text on an already blue background. I've changed the hover effect to now make the button fully white with blue text to improve readability.

Hope this is helpful 👍 